### PR TITLE
feat: Nomad variables files and HCL2 by default 

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -89,8 +89,11 @@ General Options:
     Nomad cluster. You can repeat this flag multiple times to supply multiple var-files.
     [default: levant.(json|yaml|yml|tf)]
 
-  -hcl2
-    Use HCL2 jopspec parser.
+  -disable-hcl2
+    Do not use HCL2 jopspec parser.
+
+  -nomad-var-file=<file>
+    Nomad variables file (cannot be used with -disable-hcl2)
 `
 	return strings.TrimSpace(helpText)
 }
@@ -128,9 +131,10 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.StringVar(&format, "log-format", "HUMAN", "")
 	flags.StringVar(&config.Deploy.VaultToken, "vault-token", "", "")
 	flags.BoolVar(&config.Deploy.EnvVault, "vault", false, "")
-	flags.BoolVar(&config.Template.HCL2, "hcl2", false, "")
+	flags.BoolVar(&config.Template.DisableHCL2, "disable-hcl2", false, "")
 
 	flags.Var((*helper.FlagStringSlice)(&config.Template.VariableFiles), "var-file", "")
+	flags.Var((*helper.FlagStringSlice)(&config.Template.NomadVariableFiles), "nomad-var-file", "")
 
 	if err = flags.Parse(args); err != nil {
 		return 1
@@ -162,8 +166,7 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
-	config.Template.Job, err = template.RenderJob(config.Template.TemplateFile,
-		config.Template.VariableFiles, config.Client.ConsulAddr, &c.Meta.flagVars, config.Template.HCL2)
+	config.Template.Job, err = template.RenderJob(config.Template, config.Client.ConsulAddr, &c.Meta.flagVars)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
 		return 1

--- a/command/deploy_test.go
+++ b/command/deploy_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"testing"
 
+	"github.com/hashicorp/levant/levant/structs"
 	"github.com/hashicorp/levant/template"
 )
 
@@ -30,7 +31,7 @@ func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		job, err := template.RenderJob(c.File, []string{}, "", &fVars, false)
+		job, err := template.RenderJob(&structs.TemplateConfig{TemplateFile: c.File, VariableFiles: []string{}}, "", &fVars)
 		if err != nil {
 			t.Fatalf("case %d failed: %v", i, err)
 		}
@@ -61,7 +62,7 @@ func TestDeploy_checkForceBatch(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		job, err := template.RenderJob(c.File, []string{}, "", &fVars, false)
+		job, err := template.RenderJob(&structs.TemplateConfig{TemplateFile: c.File, VariableFiles: []string{}}, "", &fVars)
 		if err != nil {
 			t.Fatalf("case %d failed: %v", i, err)
 		}

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -84,8 +84,11 @@ type TemplateConfig struct {
 	// templateFile before deployment.
 	VariableFiles []string
 
-	// HCL2 is a boolean flag that enables using jobspec2 parser
-	HCL2 bool
+	// DisableHCL2 is a boolean flag that allows to disable HCL2 jobspec parser
+	DisableHCL2 bool
+
+	// NomadVariableFiles contains a list of Nomad variables files
+	NomadVariableFiles []string
 }
 
 // ScaleConfig contains all the scaling specific configuration options.

--- a/template/render.go
+++ b/template/render.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/levant/client"
 	"github.com/hashicorp/levant/helper"
+	"github.com/hashicorp/levant/levant/structs"
 	nomad "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/jobspec"
 	"github.com/hashicorp/nomad/jobspec2"
@@ -20,19 +21,20 @@ import (
 
 // RenderJob takes in a template and variables performing a render of the
 // template followed by Nomad jobspec parse.
-func RenderJob(templateFile string, variableFiles []string, addr string, flagVars *map[string]interface{}, hcl2 bool) (job *nomad.Job, err error) {
+func RenderJob(templateConfig *structs.TemplateConfig, addr string, flagVars *map[string]interface{}) (job *nomad.Job, err error) {
 	var tpl *bytes.Buffer
-	tpl, err = RenderTemplate(templateFile, variableFiles, addr, flagVars)
+	tpl, err = RenderTemplate(templateConfig.TemplateFile, templateConfig.VariableFiles, addr, flagVars)
 	if err != nil {
 		return
 	}
 
-	if hcl2 {
+	if !templateConfig.DisableHCL2 {
 		return jobspec2.ParseWithConfig(&jobspec2.ParseConfig{
-			Path:    templateFile,
-			Body:    tpl.Bytes(),
-			AllowFS: true,
-			Strict:  true,
+			Path:     templateConfig.TemplateFile,
+			Body:     tpl.Bytes(),
+			AllowFS:  true,
+			Strict:   true,
+			VarFiles: templateConfig.NomadVariableFiles,
 		})
 	}
 

--- a/test/acctest/deploy.go
+++ b/test/acctest/deploy.go
@@ -26,7 +26,9 @@ func (c DeployTestStepRunner) Run(s *TestState) error {
 	}
 	c.Vars["job_name"] = s.JobName
 
-	job, err := template.RenderJob("fixtures/"+c.FixtureName, []string{}, "", &c.Vars, false)
+	job, err := template.RenderJob(
+		&structs.TemplateConfig{TemplateFile: "fixtures/" + c.FixtureName, VariableFiles: []string{}}, "", &c.Vars,
+	)
 	if err != nil {
 		return fmt.Errorf("error rendering template: %s", err)
 	}


### PR DESCRIPTION
This adds the -nomad-var-file flag which allows to pass a Nomad
variables file like Nomad CLI (e.g. `nomad run -var-file`).

This PRs also enables HCL2 by default and replace -hcl2 by -disable-hcl2